### PR TITLE
Image Mode - adjustments of Sanity/upstream-test-suite test

### DIFF
--- a/Sanity/upstream-test-suite/main.fmf
+++ b/Sanity/upstream-test-suite/main.fmf
@@ -3,11 +3,16 @@ contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
 require:
   - jose
+  - meson
+  - ninja-build
   - dnf-utils
   - gawk
   - grep
   - patch
   - bzip2
+  - automake
+  - autoconf
+  - libtool
 duration: 10m
 enabled: true
 tag:

--- a/Sanity/upstream-test-suite/runtest.sh
+++ b/Sanity/upstream-test-suite/runtest.sh
@@ -30,13 +30,15 @@
 . /usr/share/beakerlib/beakerlib.sh || exit 1
 
 IS_IMAGE_MODE=0
-[ -e /run/ostree-booted ] && IS_IMAGE_MODE=1
 
 rlJournalStart
     rlPhaseStartSetup
         rlAssertRpm "jose" || rlDie
         rlRun "TmpDir=\$(mktemp -d)" 0 "Creating tmp directory"
         rlRun "pushd $TmpDir"
+
+        [ -e /run/ostree-booted ] && IS_IMAGE_MODE=1
+
         if [ -d /root/rpmbuild ]; then
             rlRun "rlFileBackup --clean /root/rpmbuild" 0 "Backup rpmbuild directory"
             touch backup


### PR DESCRIPTION
## Summary by Sourcery

Adjust the upstream-test-suite runtest.sh to detect when running in an ostree-booted image and skip package installation and repo enabling accordingly.

Tests:
- Add image mode detection by checking /run/ostree-booted and setting IS_IMAGE_MODE flag.
- Conditionally skip source RPM fetching, enabling buildroot/CRB repos, running dnf builddep, and installing autotools dependencies in image mode with appropriate log messages.