### PR TITLE
Add missing tmt-IDs and reformat fmf files

### DIFF
--- a/Regression/bz1466278-file-descriptor-leaks-in-fmt/main.fmf
+++ b/Regression/bz1466278-file-descriptor-leaks-in-fmt/main.fmf
@@ -3,20 +3,21 @@ description: ''
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
 require:
-- jose
-- valgrind
+  - jose
+  - valgrind
 duration: 10m
 enabled: true
 tag:
-- CI-Tier-1
-- NoRHEL4
-- NoRHEL5
-- NoRHEL6
-- TIPfail_Security
-- Tier1
-- Tier1security
-- ImageMode
+  - CI-Tier-1
+  - NoRHEL4
+  - NoRHEL5
+  - NoRHEL6
+  - TIPfail_Security
+  - Tier1
+  - Tier1security
+  - ImageMode
 tier: '1'
 extra-summary: /CoreOS/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
 extra-task: /CoreOS/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
 extra-nitrate: TC#0561563
+id: d40d77c1-42dd-4980-bcef-dae7f41c96cd

--- a/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/main.fmf
+++ b/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/main.fmf
@@ -3,18 +3,21 @@ description: ''
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
 require:
-- jose
+  - jose
 duration: 5m
 enabled: true
 tag:
-- CI-Tier-1
-- NoRHEL4
-- NoRHEL5
-- TIPfail_Security
-- Tier1
-- Tier1security
-- ImageMode
+  - CI-Tier-1
+  - NoRHEL4
+  - NoRHEL5
+  - TIPfail_Security
+  - Tier1
+  - Tier1security
+  - ImageMode
 tier: '1'
-extra-summary: /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
-extra-task: /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
+extra-summary: 
+    /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
+extra-task: 
+    /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
 extra-nitrate: TC#0561564
+id: 68de3b23-c42c-49e3-8462-28d2002e0a50

--- a/Sanity/upstream-test-suite/main.fmf
+++ b/Sanity/upstream-test-suite/main.fmf
@@ -25,3 +25,4 @@ adjust:
   - enabled: false
     when: distro < rhel-8
     continue: false
+id: 93d0c9f5-c5ea-45e9-9234-4bfd66052c7f


### PR DESCRIPTION
## Summary by Sourcery

Add missing tmt-IDs to FMF test metadata files and reformat them for consistent styling across Regression and Sanity suites

Enhancements:
- Add missing tmt-IDs to FMF metadata files
- Reformat FMF files for consistent styling