### PR TITLE
Added missing ID

### DIFF
--- a/Regression/bz1466278-file-descriptor-leaks-in-fmt/main.fmf
+++ b/Regression/bz1466278-file-descriptor-leaks-in-fmt/main.fmf
@@ -3,20 +3,21 @@ description: ''
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
 require:
-- jose
-- valgrind
+  - jose
+  - valgrind
 duration: 10m
 enabled: true
 tag:
-- CI-Tier-1
-- NoRHEL4
-- NoRHEL5
-- NoRHEL6
-- TIPfail_Security
-- Tier1
-- Tier1security
-- ImageMode
+  - CI-Tier-1
+  - NoRHEL4
+  - NoRHEL5
+  - NoRHEL6
+  - TIPfail_Security
+  - Tier1
+  - Tier1security
+  - ImageMode
 tier: '1'
 extra-summary: /CoreOS/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
 extra-task: /CoreOS/jose/Regression/bz1466278-file-descriptor-leaks-in-fmt
 extra-nitrate: TC#0561563
+id: 5f514bc4-260e-470e-b13b-34afe19dfb28

--- a/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/main.fmf
+++ b/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/main.fmf
@@ -3,18 +3,21 @@ description: ''
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
 require:
-- jose
+  - jose
 duration: 5m
 enabled: true
 tag:
-- CI-Tier-1
-- NoRHEL4
-- NoRHEL5
-- TIPfail_Security
-- Tier1
-- Tier1security
-- ImageMode
+  - CI-Tier-1
+  - NoRHEL4
+  - NoRHEL5
+  - TIPfail_Security
+  - Tier1
+  - Tier1security
+  - ImageMode
 tier: '1'
-extra-summary: /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
-extra-task: /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
+extra-summary: 
+    /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
+extra-task: 
+    /CoreOS/jose/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data
 extra-nitrate: TC#0561564
+id: f673e4cd-4992-49cd-a8dd-ba7738efd093

--- a/Sanity/upstream-test-suite/main.fmf
+++ b/Sanity/upstream-test-suite/main.fmf
@@ -25,3 +25,4 @@ adjust:
   - enabled: false
     when: distro < rhel-8
     continue: false
+id: b863075f-a8b6-495a-a85e-3bc6fb95f8a3


### PR DESCRIPTION
Added new id tag

## Summary by Sourcery

Add missing id tags to FMF test files

Tests:
- Add id tag to Regression/bz1466278-file-descriptor-leaks-in-fmt/main.fmf
- Add id tag to Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/main.fmf
- Add id tag to Sanity/upstream-test-suite/main.fmf