### PR TITLE
Add missing descriptions to main.fmf test cases

### DIFF
--- a/Regression/bz1466278-file-descriptor-leaks-in-fmt/main.fmf
+++ b/Regression/bz1466278-file-descriptor-leaks-in-fmt/main.fmf
@@ -1,5 +1,8 @@
 summary: runs jose fmt via valgrind, checking for leaks
-description: ''
+description: |
+    Verify that jose fmt does not leak file descriptors when using the -o (output)
+    and -f (foreach) options, by running the command under valgrind with file
+    descriptor tracking enabled and checking that no descriptors remain open.
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
 require:

--- a/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/main.fmf
+++ b/Regression/bz1473248-jose-jwk-gen-segfaults-on-invalid-data/main.fmf
@@ -1,5 +1,9 @@
 summary: runs jose jwg gen with invalid input
-description: ''
+description: |
+    Verify that jose jwk gen handles invalid input gracefully without segfaulting,
+    by running it with valid JSON, an empty file, and an invalid JSON file, and
+    confirming it exits successfully for valid input and returns an error for
+    invalid or empty input.
 contact: Martin Zelený <mzeleny@redhat.com>
 test: ./runtest.sh
 require:

--- a/Sanity/upstream-test-suite/main.fmf
+++ b/Sanity/upstream-test-suite/main.fmf
@@ -1,4 +1,9 @@
 summary: Run the upstream test suite
+description: |
+    Verify that jose passes its upstream test suite by fetching the source RPM,
+    installing build dependencies, applying distribution patches, building from
+    source using meson (or autotools for older versions), and running the
+    upstream tests.
 contact: Patrik Koncity <pkoncity@redhat.com>
 test: ./runtest.sh
 require:


### PR DESCRIPTION
Add descriptions to test cases that had empty or missing description field in main.fmf.

## Summary by Sourcery

Tests:
- Populate empty or missing description fields for regression and sanity test cases in main.fmf files.